### PR TITLE
Chgabriel79/tls ca dir

### DIFF
--- a/src/core/config.h
+++ b/src/core/config.h
@@ -45,6 +45,7 @@
 #define TLS_PKEY_FILE "cert.pem" 	/*!< The certificate private key file */
 #define TLS_CERT_FILE "cert.pem"	/*!< The certificate file */
 #define TLS_CA_FILE 0			/*!< no CA list file by default */
+#define TLS_CA_DIR 0			/*!< no CA dir by default */
 #define TLS_CRL_FILE 0 /*!< no CRL by default */
 
 #define CHILD_NO    8			/*!< default number of child processes started */

--- a/src/modules/tls/doc/params.xml
+++ b/src/modules/tls/doc/params.xml
@@ -197,12 +197,46 @@ for f in trusted_cas/*.pem ; do cat "$f" &gt;&gt; ca_list.pem ; done
 		<emphasis>verify_depth</emphasis>,
 		<emphasis>require_certificate</emphasis> and
 		<emphasis>crl</emphasis>.
+		<emphasis>ca_dir</emphasis>.
 	</para>
 	<example>
 	    <title>Set <varname>ca_list</varname> parameter</title>
 	    <programlisting>
 ...
 modparam("tls", "ca_list", "/usr/local/etc/kamailio/ca_list.pem")
+...
+	    </programlisting>
+	</example>
+	</section>
+
+	<section id="tls.p.ca_dir">
+	<title><varname>ca_dir</varname> (string)</title>
+	<para>
+		Sets the CA directory. This directory contains the trusted CAs certificates
+		used when connecting to other SIP implementations. If a signature in a
+		certificate chain belongs to one of the listed CAs, the verification
+		of that certificate will succeed.
+	</para>
+	<para>
+		This directory should contain certificates in PEM format where the names
+		are the hash values of the certificate. These names be created by the command
+        <programlisting>
+ $ openssl rehash
+        </programlisting>
+	</para>
+	<para>
+		See also
+		<emphasis>verify_certificate</emphasis>,
+		<emphasis>verify_depth</emphasis>,
+		<emphasis>require_certificate</emphasis> and
+		<emphasis>crl</emphasis>.
+		<emphasis>ca_list</emphasis>.
+	</para>
+	<example>
+	    <title>Set <varname>ca_dir</varname> parameter</title>
+	    <programlisting>
+...
+			modparam("tls", "ca_dir", "/usr/local/ssl/certs")
 ...
 	    </programlisting>
 	</example>
@@ -288,10 +322,12 @@ modparam("tls", "crl", "/usr/local/etc/kamailio/crl.pem")
 		OpenSSL man page.
 	</para>
 	<para>
-		Note: the certificate verification will always fail if the ca_list is empty.
+		Note: the certificate verification will always fail if the ca_list is empty
+		and no ca_dir is given.
 	</para>
 	<para>
-		See also: <varname>ca_list</varname>, <varname>require_certificate</varname>, <varname>verify_depth</varname>.
+		See also: <varname>ca_list</varname>, <varname>require_certificate</varname>, <varname>verify_depth</varname>,
+		<varname>ca_dir</varname>.
 	</para>
 	<para>
 		By default the certificate verification is off.
@@ -313,6 +349,7 @@ modparam("tls", "verify_certificate", 1)
 	</para>
 	<para>
 		See also: <varname>ca_list</varname>, <varname>require_certificate</varname>, <varname>verify_certificate</varname>,
+		<varname>ca_dir</varname>.
 	</para>
 	<para>
 		The default value is 9.
@@ -1048,6 +1085,7 @@ modparam("tls", "renegotiation", 1)
 			<listitem><para>certificate - (str) - see modparam</para></listitem>
 			<listitem><para>verify_depth - (int) - see modparam</para></listitem>
 			<listitem><para>ca_list - (str) - see modparam</para></listitem>
+			<listitem><para>ca_dir - (str) - see modparam</para></listitem>
 			<listitem><para>crl - (str) - see modparam</para></listitem>
 			<listitem><para>cipher_list - (str) - see modparam</para></listitem>
 			<listitem><para>server_name - (str) - SNI (server name identification)</para></listitem>

--- a/src/modules/tls/tls_cfg.c
+++ b/src/modules/tls/tls_cfg.c
@@ -44,6 +44,7 @@ struct cfg_group_tls default_tls_cfg = {
 	STR_STATIC_INIT("off"), /* verify_client */
 	STR_NULL, /* private_key (default value set in fix_tls_cfg) */
 	STR_NULL, /* ca_list (default value set in fix_tls_cfg) */
+	STR_NULL, /* ca_dir (default value set in fix_tls_cfg) */
 	STR_NULL, /* crl (default value set in fix_tls_cfg) */
 	STR_NULL, /* certificate (default value set in fix_tls_cfg) */
 	STR_NULL, /* cipher_list (default value set in fix_tls_cfg) */
@@ -163,6 +164,8 @@ cfg_def_t	tls_cfg_def[] = {
 		" contained in the certificate file" },
 	{"ca_list", CFG_VAR_STR | CFG_READONLY, 0, 0, 0, 0,
 		"name of the file containing the trusted CA list (pem format)" },
+	{"ca_dir", CFG_VAR_STR | CFG_READONLY, 0, 0, 0, 0,
+		"name of the directory containing the trusted CA certificates (pem format)" },
 	{"crl", CFG_VAR_STR | CFG_READONLY, 0, 0, 0, 0,
 		"name of the file containing the CRL  (certificare revocation list"
 			" in pem format)" },
@@ -277,6 +280,8 @@ int fix_tls_cfg(struct cfg_group_tls* cfg)
 	if (fix_initial_pathname(&cfg->private_key, TLS_PKEY_FILE) < 0)
 		return -1;
 	if (fix_initial_pathname(&cfg->ca_list, TLS_CA_FILE) < 0 )
+		return -1;
+	if (fix_initial_pathname(&cfg->ca_dir, TLS_CA_DIR) < 0 )
 		return -1;
 	if (fix_initial_pathname(&cfg->crl, TLS_CRL_FILE) < 0 )
 		return -1;

--- a/src/modules/tls/tls_cfg.h
+++ b/src/modules/tls/tls_cfg.h
@@ -49,6 +49,7 @@ struct cfg_group_tls {
 	str verify_client;
 	str private_key;
 	str ca_list;
+	str ca_dir;
 	str crl;
 	str certificate;
 	str cipher_list;

--- a/src/modules/tls/tls_config.c
+++ b/src/modules/tls/tls_config.c
@@ -183,6 +183,7 @@ static cfg_option_t options[] = {
 	{"server_name_mode",    .f = cfg_parse_int_opt},
 	{"server_id",           .f = cfg_parse_str_opt, .flags = CFG_STR_SHMMEM},
 	{"verify_client",       .param = verify_client_params, .f = cfg_parse_enum_opt},
+	{"ca_dir",              .f = cfg_parse_str_opt, .flags = CFG_STR_SHMMEM},
 	{0}
 };
 
@@ -212,6 +213,7 @@ static void update_opt_variables(void)
 	for(i = 0; verify_client_params[i].name; i++) {
 		verify_client_params[i].param = &_ksr_tls_domain->verify_client;
 	}
+	options[18].param = &_ksr_tls_domain->ca_dir;
 }
 
 

--- a/src/modules/tls/tls_domain.h
+++ b/src/modules/tls/tls_domain.h
@@ -117,6 +117,7 @@ typedef struct tls_domain {
 	int verify_cert;
 	int verify_depth;
 	str ca_file;
+	str ca_dir;
 	int require_cert;
 	str cipher_list;
 	enum tls_method method;

--- a/src/modules/tls/tls_mod.c
+++ b/src/modules/tls/tls_mod.c
@@ -101,6 +101,7 @@ static tls_domain_t mod_params = {
 	0,                /* Verify certificate */
 	9,                /* Verify depth */
 	STR_STATIC_INIT(TLS_CA_FILE),      /* CA file */
+	STR_STATIC_INIT(TLS_CA_DIR),       /* CA dir */
 	0,                /* Require certificate */
 	{0, },                /* Cipher list */
 	TLS_USE_TLSv1_PLUS,   /* TLS method */
@@ -212,6 +213,7 @@ static param_export_t params[] = {
 	{"verify_client",       PARAM_STR,    &default_tls_cfg.verify_client},
 	{"private_key",         PARAM_STR,    &default_tls_cfg.private_key  },
 	{"ca_list",             PARAM_STR,    &default_tls_cfg.ca_list      },
+	{"ca_dir",              PARAM_STR,    &default_tls_cfg.ca_dir       },
 	{"certificate",         PARAM_STR,    &default_tls_cfg.certificate  },
 	{"crl",                 PARAM_STR,    &default_tls_cfg.crl          },
 	{"cipher_list",         PARAM_STR,    &default_tls_cfg.cipher_list  },
@@ -330,6 +332,7 @@ static int mod_init(void)
 	mod_params.require_cert = cfg_get(tls, tls_cfg, require_cert);
 	mod_params.pkey_file = cfg_get(tls, tls_cfg, private_key);
 	mod_params.ca_file = cfg_get(tls, tls_cfg, ca_list);
+	mod_params.ca_dir= cfg_get(tls, tls_cfg, ca_dir);
 	mod_params.crl_file = cfg_get(tls, tls_cfg, crl);
 	mod_params.cert_file = cfg_get(tls, tls_cfg, certificate);
 	mod_params.cipher_list = cfg_get(tls, tls_cfg, cipher_list);

--- a/src/modules/tls/tls_rpc.c
+++ b/src/modules/tls/tls_rpc.c
@@ -229,6 +229,7 @@ static void tls_options(rpc_t* rpc, void* c)
 		"verify_client",	&cfg_get(tls, tls_cfg, verify_client),
 		"private_key",		&cfg_get(tls, tls_cfg, private_key),
 		"ca_list",			&cfg_get(tls, tls_cfg, ca_list),
+		"ca_dir",			&cfg_get(tls, tls_cfg, ca_list),
 		"certificate",		&cfg_get(tls, tls_cfg, certificate),
 		"cipher_list",		&cfg_get(tls, tls_cfg, cipher_list),
 		"session_cache",	cfg_get(tls, tls_cfg, session_cache),


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [x] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->
tls: add config parameter ca_dir

`ca_dir` can be set to allow OpenSSL to read a list of trusted CA certificates from a directory.
This greatly reduces startup times and memory usage if many CA certificates are used because the CA certificates are loaded for each child process and each SSL profile defined.